### PR TITLE
Adapt Directus module for Nuxt 3.4 runtime config changes

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -57,7 +57,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Nuxt 3
     nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
-    nuxt.options.runtimeConfig.public.directus = defu(nuxt.options.runtimeConfig.directus, {
+    nuxt.options.runtimeConfig.public.directus = defu(nuxt.options.runtimeConfig.public.directus, {
       url: options.url,
       autoFetch: options.autoFetch,
       fetchUserParams: options.fetchUserParams,

--- a/src/runtime/composables/useDirectus.ts
+++ b/src/runtime/composables/useDirectus.ts
@@ -17,8 +17,8 @@ export const useDirectus = () => {
 
     if (token && token.value) {
       headers.Authorization = `Bearer ${token.value}`;
-    } else if (config.directus.token && useStaticToken) {
-      headers.Authorization = `Bearer ${config.directus.token}`;
+    } else if (config.public.directus.token && useStaticToken) {
+      headers.Authorization = `Bearer ${config.public.directus.token}`;
     }
 
     try {

--- a/src/runtime/composables/useDirectusAuth.ts
+++ b/src/runtime/composables/useDirectusAuth.ts
@@ -38,19 +38,19 @@ export const useDirectusAuth = () => {
   const fetchUser = async (useStaticToken?: boolean): Promise<Ref<DirectusUser>> => {
     if (token.value) {
       try {
-        if (config.directus.fetchUserParams?.filter) {
-          (config.directus.fetchUserParams.filter as unknown) = JSON.stringify(
-            config.directus.fetchUserParams.filter
+        if (config.public.directus.fetchUserParams?.filter) {
+          (config.public.directus.fetchUserParams.filter as unknown) = JSON.stringify(
+            config.public.directus.fetchUserParams.filter
           )
         }
-        if (config.directus.fetchUserParams?.deep) {
-          (config.directus.fetchUserParams.deep as unknown) = JSON.stringify(
-            config.directus.fetchUserParams.deep
+        if (config.public.directus.fetchUserParams?.deep) {
+          (config.public.directus.fetchUserParams.deep as unknown) = JSON.stringify(
+            config.public.directus.fetchUserParams.deep
           )
         }
-        if (config.directus.fetchUserParams) {
+        if (config.public.directus.fetchUserParams) {
           const res = await directus<{ data: DirectusUser }>('/users/me', {
-            params: config.directus.fetchUserParams
+            params: config.public.directus.fetchUserParams
           }, useStaticToken)
           setUser(res.data)
         } else {

--- a/src/runtime/composables/useDirectusFiles.ts
+++ b/src/runtime/composables/useDirectusFiles.ts
@@ -45,8 +45,8 @@ export const useDirectusFiles = () => {
     }
     if (token && token.value) {
       url.searchParams.append('access_token', token.value)
-    } else if (config.directus.token) {
-      url.searchParams.append('access_token', config.directus.token)
+    } else if (config.public.directus.token) {
+      url.searchParams.append('access_token', config.public.directus.token)
     }
     return url.href
   }

--- a/src/runtime/composables/useDirectusUrl.ts
+++ b/src/runtime/composables/useDirectusUrl.ts
@@ -2,5 +2,5 @@ import { useRuntimeConfig } from '#app'
 
 export const useDirectusUrl = (): string => {
   const config = useRuntimeConfig()
-  return config.directus.url
+  return config.public.directus.url
 }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -3,7 +3,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const config = useRuntimeConfig()
-  if (config.directus.autoFetch) {
+  if (config.public.directus.autoFetch) {
     const { fetchUser } = useDirectusAuth()
 
     await fetchUser()


### PR DESCRIPTION
Adapted the Directus Nuxt module to work with Nuxt 3.4's updated runtime configuration handling, following the deprecation of old (pre-rc) runtimeConfig.

For more information, check out https://github.com/nuxt/nuxt/pull/20082.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description

This PR adapts the Directus Nuxt module to work with Nuxt 3.4's updated runtime configuration handling. This is necessary due to the deprecation of old (pre-rc) runtimeConfig. The changes ensure that the module continues to work as expected with the latest version of Nuxt.

For more information, please see https://github.com/nuxt/nuxt/pull/20082.

Closes #126.